### PR TITLE
Fixed missing templates folder after pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(name='django-simple-menu',
-      packages=find_packages(),
+      packages=['menu'],
+      include_package_data=True,
       version='1.0.4',
       description='Simple, yet powerful, code-based menus for Django applications',
       long_description=open('README.rst').read(),


### PR DESCRIPTION
I noticed that after latest update of package my menu disappears. I took me while but finally found out that after pip install only templatetags folder was installed and templates with bootstrap nav menu template was missing. After few tweaks and referring to Django docs I fixed it and sending pull request.
