### PR TITLE
Defer import of django.conf.settings

### DIFF
--- a/menu/__init__.py
+++ b/menu/__init__.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 import traceback
 import sys
 import re
@@ -52,6 +50,9 @@ class Menu(object):
         if c.loaded == True:
             return
 
+        # deferred import of django settings module
+        from django.conf import settings
+        
         # loop through our INSTALLED_APPS
         for app in settings.INSTALLED_APPS:
             # skip any django apps


### PR DESCRIPTION
This fixes installation issues related to this file being imported into setup.py

Without this change I intermittently recieve the following error:

```
Downloading/unpacking django-simple-menu==1.0.6 (from -r requirements.txt (line 52))
  Running setup.py egg_info for package django-simple-menu
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/Users/jacob/.virtualenvs/gizmag/build/django-simple-menu/setup.py", line 5, in <module>
        from menu import VERSION_STRING
      File "menu/__init__.py", line 1, in <module>
        from django.conf import settings
    ImportError: No module named django.conf
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/Users/jacob/.virtualenvs/gizmag/build/django-simple-menu/setup.py", line 5, in <module>

    from menu import VERSION_STRING

  File "menu/__init__.py", line 1, in <module>

    from django.conf import settings

ImportError: No module named django.conf
```
