### PR TITLE
Include documentation in source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include CHANGES
 include AUTHORS
 recursive-include menu/templates *
 recursive-include menu/templatetags *
+recursive-include docs *


### PR DESCRIPTION
it would be nice to have the documentation in the source distribution too so one can build it using sphinx. This is the case for a Debian package that I'm working on right now.
