### PR TITLE
always reset visibility

### DIFF
--- a/menu/menu.py
+++ b/menu/menu.py
@@ -231,11 +231,10 @@ class MenuItem(object):
             kid.parent = self
 
     def check_check(self, request):
-        # reset visibility on every request
-        self.visible = self.default_visible
-
         if callable(self.check):
             self.visible = self.check(request)
+        else:
+            self.visible = self.default_visible
 
     def check_title(self, request):
         if callable(self._title):


### PR DESCRIPTION
There is a bug in multi user environments:

The visibility of an item does not get reset between requests of different users. Therefore a user with a lot of privileges will not see all of it's menu items when a user with less privileges already populated the visible flag of a menu item.
It's not possible to restore the default value of visible since it is overwritten by the check callback.
