### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/menu/menu.py
+++ b/menu/menu.py
@@ -1,8 +1,8 @@
 import copy
 import re
-import sys
 
 from django.conf import settings
+from django.utils.six import text_type
 from django.utils.text import slugify
 
 try:
@@ -206,13 +206,7 @@ class MenuItem(object):
             self.title = self.title(request)
 
         # if no title is set turn it into a slug
-        if self.slug is None:
-            # in python3 we don't need to convert to unicode, in python2 slugify
-            # requires a unicode string
-            if sys.version_info > (3, 0):
-                self.slug = slugify(self.title)
-            else:
-                self.slug = slugify(unicode(self.title))
+        self.slug = self.slug or slugify(text_type(self.title))
 
         # evaluate children
         if callable(self.children):


### PR DESCRIPTION
Python porting best practice https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection

Also deal with the situation where __self.slug__ has other _falsey_ values such as __""__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/jazzband/django-simple-menu on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./menu/menu.py:215:37: F821 undefined name 'unicode'
                self.slug = slugify(unicode(self.title))
                                    ^
1     F821 undefined name 'unicode'
1
```