### PR TITLE
Travis CI: fix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
   - pypy
 
 env:
@@ -17,22 +18,28 @@ env:
 
 matrix:
   exclude:
-    - python: 2.6
-      env: DJANGO=Django==1.7
-
-    - python: 2.6
-      env: DJANGO=Django==1.8
-
-    - python: 2.6
-      env: DJANGO=Django==1.9
-
-    - python: 3.3
-      env: DJANGO=Django==1.9
-
     - python: 3.5
       env: DJANGO=Django==1.6
 
     - python: 3.5
+      env: DJANGO=Django==1.7
+
+    - python: 3.6
+      env: DJANGO=Django==1.6
+
+    - python: 3.6
+      env: DJANGO=Django==1.7
+
+    - python: 3.7
+      env: DJANGO=Django==1.6
+
+    - python: 3.7
+      env: DJANGO=Django==1.7
+
+    - python: 3.8
+      env: DJANGO=Django==1.6
+
+    - python: 3.8
       env: DJANGO=Django==1.7
 
 install:


### PR DESCRIPTION
 - Python 2.6 is no longer available on Travis
 - Python 3.3 is no longer available on Travis
 - Add python 3.6, 3.7, 3.8