### PR TITLE
Allow MenuItem url to be callable

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,8 +29,15 @@ The ``MenuItem`` class should be instantiated and passed to the ``add_item``
 class method with the appropriate parameters. ``MenuItem`` accepts a wide
 number of options to its constructor method, the majority of which are simply
 attributes that become available in your templates when you're rendering out
-the menus. The required arguments to MenuItem are the first two; the title of
-the menu and the URL, and the keywords that affect menu generation are:
+the menus. 
+
+``MenuItem`` requires the first two arguments: 
+
+ * The ``title`` of the item
+ * The ``url`` of the item, which can be a string or a callable which accepts the request 
+ object and returns a string.
+ 
+The keywords that affect menu generation are:
 
 * The ``weight`` keyword argument affects sorting of the menu.
 * The ``children`` keyword argument is either a list of ``MenuItem`` objects,

--- a/menu/menu.py
+++ b/menu/menu.py
@@ -154,7 +154,7 @@ class MenuItem(object):
         MenuItem constructor
 
         title       either a string or a callable to be used for the title
-        url         the url of the item
+        url         the url of the item or a callable to be used for the url
         children    an array of MenuItems that are sub menus to this item
                     this can also be a callable that generates an array
         weight      used to sort adjacent MenuItems
@@ -201,6 +201,10 @@ class MenuItem(object):
         if not self.visible:
             return
 
+        # evaluate our url
+        if callable(self.url):
+            self.url = self.url(request)
+        
         # evaluate our title
         if callable(self.title):
             self.title = self.title(request)

--- a/menu/tests/test_menu.py
+++ b/menu/tests/test_menu.py
@@ -45,6 +45,13 @@ class MenuTests(TestCase):
                 return "-".join([request.path, self.kids3_2_desired_title])
             return 'kids3-2'
 
+        self.kids3_2_desired_url = None
+        def kids3_2_url(request):
+            "Allow the url of kids3-2 to be changed"
+            if self.kids3_2_desired_url is not None:
+                return '/'.join([request.path, self.kids3_2_desired_url])
+            return '/parent3/kids3-2'
+
         def kids2_2_check(request):
             "Hide kids2-2 whenever the request path ends with /hidden"
             if request.path.endswith('/hidden'):
@@ -72,7 +79,7 @@ class MenuTests(TestCase):
 
         kids3 = (
             CustomMenuItem("kids3-1", "/parent3/kids3-1", children=kids3_1, slug="salty"),
-            CustomMenuItem(kids3_2_title, "/parent3/kids3-2")
+            CustomMenuItem(kids3_2_title, kids3_2_url)
         )
 
         Menu.items = {}
@@ -166,6 +173,15 @@ class MenuTests(TestCase):
         request = self.factory.get('/parent3')
         items = Menu.process(request, 'test')
         self.assertEqual(items[1].children[1].title, "/parent3-fun")
+
+    def test_callable_url(self):
+        """
+        Ensure callable urls work
+        """
+        self.kids3_2_desired_url = "custom"
+        request = self.factory.get('/parent3')
+        items = Menu.process(request, 'test')
+        self.assertEqual(items[1].children[1].url, "/parent3/custom")
 
     def test_select_parents(self):
         """


### PR DESCRIPTION
Treats `url` the same way as `title`, `children`.  Handles cases like #70 without the need for subclassing.