### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: mixed-line-ending
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
+-   repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.5.0
+    hooks:
+    -   id: django-upgrade
+        args: [--target-version, "2.2"]
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+    -   id: python-check-blanket-noqa
+    -   id: python-check-mock-methods
+    -   id: python-no-eval
+    -   id: python-no-log-warn
+    -   id: rst-backticks
+    -   id: rst-directive-colons

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # django-simple-menu documentation build configuration file, created by
 # sphinx-quickstart on Thu Feb 21 16:24:33 2013.
@@ -42,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-simple-menu'
-copyright = u'2014, Evan Borgstrom'
+project = 'django-simple-menu'
+copyright = '2014, Evan Borgstrom'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +184,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'django-simple-menu.tex', u'django-simple-menu Documentation',
-   u'Evan Borgstrom', 'manual'),
+  ('index', 'django-simple-menu.tex', 'django-simple-menu Documentation',
+   'Evan Borgstrom', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,8 +214,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'django-simple-menu', u'django-simple-menu Documentation',
-     [u'Evan Borgstrom'], 1)
+    ('index', 'django-simple-menu', 'django-simple-menu Documentation',
+     ['Evan Borgstrom'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -229,8 +228,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'django-simple-menu', u'django-simple-menu Documentation',
-   u'Evan Borgstrom', 'django-simple-menu', 'One line description of project.',
+  ('index', 'django-simple-menu', 'django-simple-menu Documentation',
+   'Evan Borgstrom', 'django-simple-menu', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,5 +12,3 @@ Installing django-simple-menu
    means that you need to ensure that your ``TEMPLATE_CONTEXT_PROCESSORS``
    setting includes ``django.core.context_processors.request``, which it
    doesn't by default.
-
-

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,7 +44,7 @@ available in your templates. For example adding ``separator=True`` could be
 used to add separators to menus ``{% if item.separator %}<li
 class="divider"></li>{% endif %}``
 
-For the full list of ``MenuItem`` options see the `menu __init__.py source file`_. 
+For the full list of ``MenuItem`` options see the `menu __init__.py source file`_.
 
 Usage Example
 -------------
@@ -93,7 +93,7 @@ templates. This is done through the ``generate_menu`` template tag::
 
     {% extends "base.html" %}
     {% load menu %}
-    
+
     {% block content %}
     {% generate_menu %}
     ...
@@ -102,7 +102,7 @@ templates. This is done through the ``generate_menu`` template tag::
 Note that ``generate_menu`` must be called inside of a block.
 
 Once you call ``generate_menu`` all of your MenuItems will be evaluated and
-the following items will be set in the context for you. 
+the following items will be set in the context for you.
 
 #. ``menus`` - This is an object that contains all of the lists of menus as
    attribute names::

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,15 +1,15 @@
-from django.conf.urls import patterns, include, url
-from django.contrib import admin
+from django.urls import include, path, re_path
+from django.conf.urls import patterns,  django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^admin/', include(admin.site.urls)),
+    re_path(r'^admin/', include(admin.site.urls)),
 
-    url(r'^accounts/login/$', 'django.contrib.auth.views.login'),
-    url(r'^accounts/logout/$', 'django.contrib.auth.views.logout'),
+    path('accounts/login/', 'django.contrib.auth.views.login'),
+    path('accounts/logout/', 'django.contrib.auth.views.logout'),
 
-    url(r'^accounts/', include("accounts.urls")),
-    url(r'^reports/', include("reports.urls")),
-    url(r'', "accounts.views.index"),
+    re_path(r'^accounts/', include("accounts.urls")),
+    re_path(r'^reports/', include("reports.urls")),
+    re_path(r'', "accounts.views.index"),
 )

--- a/menu/__init__.py
+++ b/menu/__init__.py
@@ -1,5 +1,5 @@
 from pkg_resources import get_distribution, DistributionNotFound
-from .menu import Menu, MenuItem  # noqa
+from .menu import Menu, MenuItem
 
 try:
     __version__ = get_distribution("django-simple-menu").version

--- a/menu/menu.py
+++ b/menu/menu.py
@@ -245,7 +245,7 @@ class MenuItem:
         """
         matched = False
         if self.exact_url:
-            if re.match("%s$" % (self.url,), request.path):
+            if re.match(f"{self.url}$", request.path):
                 matched = True
         elif re.match("%s" % self.url, request.path):
             matched = True


### PR DESCRIPTION
This fixes the CI issue we've had (mentioned in #78) and helps keep the project clean.

I've taken config from "django-debug-toolbar" as an example, omitting flake8, doc8, and black. The former two may be brought back in later, but now they just generate unnecessary errors. Black may be incorporated as code style checker and formatter, but it's not the most important right now.