### PR TITLE
Update setup configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools_scm"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "post-release"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,31 @@
+[metadata]
+name = django-simple-menu
+url = https://github.com/jazzband/django-simple-menu
+author = Evan Borgstrom
+author_email = evan@borgstrom.ca
+description = Simple, yet powerful, code-based menus for Django applications
+long_description = file: README.rst
+license = BSD 2-Clause "Simplified" License
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Framework :: Django
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Python Modules
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+packages = menu
+include_package_data = True
+python_requires = >=3.6,<4.0
+install_requires =
+    Django>=2.2

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setuptools import setup
 
-setup(
-    name="django-simple-menu",
-    packages=["menu"],
-    include_package_data=True,
-    use_scm_version={"version_scheme": "post-release"},
-    setup_requires=["setuptools_scm"],
-    description="Simple, yet powerful, code-based menus for Django applications",
-    long_description=open("README.rst").read(),
-    author="Evan Borgstrom",
-    author_email="evan@borgstrom.ca",
-    url="https://github.com/jazzband/django-simple-menu",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
-        "Framework :: Django :: 3.1",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Natural Language :: English",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ],
-    install_requires=["Django>=2.2"],
-    python_requires=">=3.6",
-)
+setup()


### PR DESCRIPTION
Both [PyPA](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata) and [setuptools](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use) recommend two things:

- using `pyproject.toml` to declare the build system (since `setuptools` is not the only one any more)
- using `setup.cfg` (declarative) config file instead of `setup.py` to reduce boilerplate code

This PR does just that.