### PR TITLE
Allow MenuItem url to be callable (rebased)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,14 +23,14 @@ The ``MenuItem`` class should be instantiated and passed to the ``add_item``
 class method with the appropriate parameters. ``MenuItem`` accepts a wide
 number of options to its constructor method, the majority of which are simply
 attributes that become available in your templates when you're rendering out
-the menus. 
+the menus.
 
-``MenuItem`` requires the first two arguments: 
+``MenuItem`` requires the first two arguments:
 
  * The ``title`` of the item
- * The ``url`` of the item, which can be a string or a callable which accepts the request 
+ * The ``url`` of the item, which can be a string or a callable which accepts the request
  object and returns a string.
- 
+
 The keywords that affect menu generation are:
 
 * The ``weight`` keyword argument affects sorting of the menu.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,8 +23,15 @@ The ``MenuItem`` class should be instantiated and passed to the ``add_item``
 class method with the appropriate parameters. ``MenuItem`` accepts a wide
 number of options to its constructor method, the majority of which are simply
 attributes that become available in your templates when you're rendering out
-the menus. The required arguments to MenuItem are the first two; the title of
-the menu and the URL, and the keywords that affect menu generation are:
+the menus. 
+
+``MenuItem`` requires the first two arguments: 
+
+ * The ``title`` of the item
+ * The ``url`` of the item, which can be a string or a callable which accepts the request 
+ object and returns a string.
+ 
+The keywords that affect menu generation are:
 
 * The ``weight`` keyword argument affects sorting of the menu.
 * The ``children`` keyword argument is either a list of ``MenuItem`` objects,

--- a/simple_menu/menu.py
+++ b/simple_menu/menu.py
@@ -194,6 +194,10 @@ class MenuItem:
         if not self.visible:
             return
 
+        # evaluate our url
+        if callable(self.url):
+            self.url = self.url(request)
+
         # evaluate our title
         if callable(self.title):
             self.title = self.title(request)

--- a/simple_menu/tests/test_menu.py
+++ b/simple_menu/tests/test_menu.py
@@ -39,6 +39,13 @@ class MenuTests(TestCase):
                 return "-".join([request.path, self.kids3_2_desired_title])
             return 'kids3-2'
 
+        self.kids3_2_desired_url = None
+        def kids3_2_url(request):
+            "Allow the url of kids3-2 to be changed"
+            if self.kids3_2_desired_url is not None:
+                return '/'.join([request.path, self.kids3_2_desired_url])
+            return '/parent3/kids3-2'
+
         def kids2_2_check(request):
             "Hide kids2-2 whenever the request path ends with /hidden"
             if request.path.endswith('/hidden'):
@@ -66,7 +73,7 @@ class MenuTests(TestCase):
 
         kids3 = (
             CustomMenuItem("kids3-1", "/parent3/kids3-1", children=kids3_1, slug="salty"),
-            CustomMenuItem(kids3_2_title, "/parent3/kids3-2")
+            CustomMenuItem(kids3_2_title, kids3_2_url)
         )
 
         Menu.items = {}
@@ -160,6 +167,15 @@ class MenuTests(TestCase):
         request = self.factory.get('/parent3')
         items = Menu.process(request, 'test')
         self.assertEqual(items[1].children[1].title, "/parent3-fun")
+
+    def test_callable_url(self):
+        """
+        Ensure callable urls work
+        """
+        self.kids3_2_desired_url = "custom"
+        request = self.factory.get('/parent3')
+        items = Menu.process(request, 'test')
+        self.assertEqual(items[1].children[1].url, "/parent3/custom")
 
     def test_select_parents(self):
         """


### PR DESCRIPTION
Hello,

I've taken the liberty to rebase what @timnyborg in #71 had done to make URLs callable, so that it can be merged for v2.X.

He is still the author of 2/3 commits, but has files moved not of the third.

Cheers!