### PR TITLE
Fix tox testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Tox tests
       run: |
-        tox -v
+        tox -v run
       env:
         DJANGO: ${{ matrix.django-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
             python-version: '3.6'
           - django-version: 'main'
             python-version: '3.7'
+          - django-version: 'main'
+            python-version: '3.8'
+          - django-version: 'main'
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,6 @@ deps =
 setenv =
     DJANGO_SETTINGS_MODULE=simple_menu.test_settings
 commands =
-    coverage run {envbindir}/django-admin test -v2 {posargs:simple_menu}
+    coverage run -m django test -v2 {posargs:simple_menu}
     coverage report
     coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ usedevelop = true
 envlist =
     py{36,37,38,39,310}-dj32
     py{38,39,310}-dj40
-    py{38,39,310,311}-dj{41,main}
+    py{38,39,310,311}-dj41
+    py{310,311}-djmain
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-skipsdist = true
 usedevelop = true
 envlist =
     py{36,37,38,39,310}-dj32


### PR DESCRIPTION
In tox v4, `skipdist` together with `usedevelop` do not work: tox-dev/tox#2730

I do not understand why we use both options, since we do not lint the
code with tox (or similar), so we actually need to install the package
every time.

Closes #123