### PR TITLE
Install importlib_metadata on old Python only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,6 @@ include_package_data = True
 python_requires = >=3.6,<4.0
 install_requires =
     Django>=2.2
-    importlib_metadata
+    importlib_metadata; python_version < '3.8'
 setup_requires =
     setuptools_scm

--- a/simple_menu/__init__.py
+++ b/simple_menu/__init__.py
@@ -1,4 +1,9 @@
-from importlib_metadata import PackageNotFoundError, version
+import sys
+
+if sys.version_info < (3, 8):  # pragma: <3.8 cover
+    from importlib_metadata import PackageNotFoundError, version
+else:  # pragma: >=3.8 cover
+    from importlib.metadata import PackageNotFoundError, version
 
 from .menu import Menu, MenuItem
 


### PR DESCRIPTION
Closes #121

The `pragma` comments do not make sense now, as they will work after merging #125 