### PR TITLE
Add Python 3.12, Django 4.2 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,32 +9,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
-        django-version: ['3.2', '4.0', '4.1', 'main']
-        exclude:
+        # https://docs.djangoproject.com/faq/install/#what-python-version-can-i-use-with-django
+        include:
           - django-version: '3.2'
-            python-version: '3.11'
-
-          - django-version: '4.0'
             python-version: '3.6'
-          - django-version: '4.0'
+          - django-version: '3.2'
             python-version: '3.7'
-          - django-version: '4.0'
-            python-version: '3.11'
-
-          - django-version: '4.1'
-            python-version: '3.6'
-          - django-version: '4.1'
-            python-version: '3.7'
-
-          - django-version: 'main'
-            python-version: '3.6'
-          - django-version: 'main'
-            python-version: '3.7'
-          - django-version: 'main'
+          - django-version: '3.2'
             python-version: '3.8'
-          - django-version: 'main'
+          - django-version: '3.2'
             python-version: '3.9'
+          - django-version: '3.2'
+            python-version: '3.10'
+
+          - django-version: '4.0'
+            python-version: '3.8'
+          - django-version: '4.0'
+            python-version: '3.9'
+          - django-version: '4.0'
+            python-version: '3.10'
+
+          - django-version: '4.1'
+            python-version: '3.8'
+          - django-version: '4.1'
+            python-version: '3.9'
+          - django-version: '4.1'
+            python-version: '3.10'
+          - django-version: '4.1'
+            python-version: '3.11'
+
+          - django-version: '4.2'
+            python-version: '3.8'
+          - django-version: '4.2'
+            python-version: '3.9'
+          - django-version: '4.2'
+            python-version: '3.10'
+          - django-version: '4.2'
+            python-version: '3.11'
+
+          - django-version: 'main'
+            python-version: '3.10'
+          - django-version: 'main'
+            python-version: '3.11'
+          - django-version: 'main'
+            python-version: '3.12'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    tags: ["*"]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,20 +61,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/tox.ini') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-v1-
+        cache: pip
 
     - name: Install dependencies
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 usedevelop = true
+; https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{36,37,38,39,310}-dj32
-    py{38,39,310}-dj40
-    py{38,39,310,311}-dj41
-    py{310,311}-djmain
+    py3{6,7,8,9,10}-dj32
+    py3{8,9,10}-dj40
+    py3{8,9,10,11}-dj41
+    py3{8,9,10,11}-dj42
+    py3{10,11,12}-djmain
 
 [gh-actions]
 python =
@@ -14,12 +16,14 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =
     3.2: dj32
     4.0: dj40
     4.1: dj41
+    4.2: dj42
     main: djmain
 
 [testenv]
@@ -28,7 +32,8 @@ deps =
     coverage
     dj32: Django~=3.2.16
     dj40: Django~=4.0.8
-    dj41: Django~=4.1.2
+    dj41: Django~=4.1.3
+    dj42: Django~=4.2.1
     djmain: https://github.com/django/django/tarball/main
 setenv =
     DJANGO_SETTINGS_MODULE=simple_menu.test_settings


### PR DESCRIPTION
This PR adds Django 4.2 to the CI rig. It also adds Python 3.12 (currently in beta) to Django `main` version.

Apart from this, this PR improves CI by not running it on every push and by using the built-in cache of `@actions/setup-python`