### PR TITLE
Improve DX

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[run]
-source = simple_menu
-branch = 1
-
-[report]
-omit = *migrations*,.tox/*,setup.py,*settings.py,menu/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   build:
     name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+    autoupdate_schedule: monthly
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,7 @@ repos:
     rev: "0.12.1"
     hooks:
     -   id: pyproject-fmt
+-   repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: "1.2.0"
+    hooks:
+    -   id: tox-ini-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,7 @@ repos:
     -   id: python-no-log-warn
     -   id: rst-backticks
     -   id: rst-directive-colons
+-   repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v2.3.0
+    hooks:
+    -   id: setup-cfg-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,11 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: mixed-line-ending
+    -   id: check-toml
+    -   id: check-yaml
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.7.0
     hooks:
@@ -29,3 +30,7 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: setup-cfg-fmt
+-   repo: https://github.com/tox-dev/pyproject-fmt
+    rev: "0.12.1"
+    hooks:
+    -   id: pyproject-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,12 @@ requires = [
 # this empty section means: use_scm_version=True
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
+
+[tool.coverage.run]
+source = [
+  "simple_menu",
+]
+plugins = ["covdefaults"]
+
+[tool.coverage.report]
+fail_under = 85

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=42",
+  "setuptools_scm[toml]>=3.4",
+]
 
 [tool.setuptools_scm]
 # this empty section means: use_scm_version=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,25 +1,25 @@
 [metadata]
-name = django-simple-menu
+name = django_simple_menu
+description = Simple, yet powerful, code-based menus for Django applications
+long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/jazzband/django-simple-menu
 author = Evan Borgstrom
 author_email = evan@borgstrom.ca
-description = Simple, yet powerful, code-based menus for Django applications
-long_description = file: README.rst
-license = BSD 2-Clause "Simplified" License
+license = BSD-2-Clause
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Topic :: Software Development :: Libraries
-    Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python
-    Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -27,15 +27,18 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 packages =
     simple_menu
     menu
-include_package_data = True
-python_requires = >=3.6,<4.0
 install_requires =
     Django>=2.2
-    importlib_metadata; python_version < '3.8'
+    importlib-metadata;python_version < '3.8'
+python_requires = >=3.6,<4.0
+include_package_data = True
 setup_requires =
-    setuptools_scm
+    setuptools-scm

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-from setuptools import setup
-
-setup()

--- a/simple_menu/__init__.py
+++ b/simple_menu/__init__.py
@@ -9,7 +9,7 @@ from .menu import Menu, MenuItem
 
 try:
     __version__ = version("django-simple-menu")
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     __version__ = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,27 @@
 [tox]
-usedevelop = true
-; https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py3{6,7,8,9,10}-dj32
-    py3{8,9,10}-dj40
-    py3{8,9,10,11}-dj41
-    py3{8,9,10,11}-dj42
-    py3{10,11,12}-djmain
+    py3{11, 10, 9, 8}-dj42
+    py3{11, 10, 9, 8}-dj41
+    py3{10, 9, 8}-dj40
+    py3{10, 9, 8, 7, 6}-dj32
+    py3{12, 11, 10}-djmain
+usedevelop = true
+
+[testenv]
+usedevelop = true
+deps =
+    coverage
+    dj32: Django~=3.2.16
+    dj40: Django~=4.0.8
+    dj41: Django~=4.1.3
+    dj42: Django~=4.2.1
+    djmain: https://github.com/django/django/tarball/main
+setenv =
+    DJANGO_SETTINGS_MODULE = simple_menu.test_settings
+commands =
+    coverage run -m django test -v2 {posargs:simple_menu}
+    coverage report
+    coverage xml
 
 [gh-actions]
 python =
@@ -19,25 +34,9 @@ python =
     3.12: py312
 
 [gh-actions:env]
-DJANGO =
+django =
     3.2: dj32
     4.0: dj40
     4.1: dj41
     4.2: dj42
     main: djmain
-
-[testenv]
-usedevelop = true
-deps =
-    coverage
-    dj32: Django~=3.2.16
-    dj40: Django~=4.0.8
-    dj41: Django~=4.1.3
-    dj42: Django~=4.2.1
-    djmain: https://github.com/django/django/tarball/main
-setenv =
-    DJANGO_SETTINGS_MODULE=simple_menu.test_settings
-commands =
-    coverage run -m django test -v2 {posargs:simple_menu}
-    coverage report
-    coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ usedevelop = true
 usedevelop = true
 deps =
     covdefaults
-    coverage
+    coverage[toml]
     dj32: Django~=3.2.16
     dj40: Django~=4.0.8
     dj41: Django~=4.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ usedevelop = true
 [testenv]
 usedevelop = true
 deps =
+    covdefaults
     coverage
     dj32: Django~=3.2.16
     dj40: Django~=4.0.8

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ deps =
     dj41: Django~=4.1.3
     dj42: Django~=4.2.1
     djmain: https://github.com/django/django/tarball/main
+pass_env =
+    FORCE_COLOR
+    NO_COLOR
 setenv =
     DJANGO_SETTINGS_MODULE = simple_menu.test_settings
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py3{10, 9, 8}-dj40
     py3{10, 9, 8, 7, 6}-dj32
     py3{12, 11, 10}-djmain
+isolated_build = true
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,8 @@ envlist =
     py3{10, 9, 8}-dj40
     py3{10, 9, 8, 7, 6}-dj32
     py3{12, 11, 10}-djmain
-usedevelop = true
 
 [testenv]
-usedevelop = true
 deps =
     covdefaults
     coverage[toml]


### PR DESCRIPTION
This PR aims to improve DX. Changes:

- remove `setup.py`
  - I wish we could replace `setup.cfg` with `pyproject.toml`, but it doesn't work with tox v4 and editable installs. Instead of replacing other build system parts, let's just wait until April 2024
- add auto-formatters for certain files
  - `setup-cfg-fmt` for setup.cfg
  - `pyproject-fmt` for pyproject.toml
  - `tox-ini-fmt`
    - **not the newest version**, since it sets tox version to 4+. This wouldn't work well for us at the moment, since we still test under Python 3.6 with Tox v3. Let's wait until April 2024
- move coverage config to pyproject.toml
- add `covdefaults` for better coverage settings
---
This PR replaces #119 