### PR TITLE
Use legacy tox command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Tox tests
       run: |
-        tox -v run
+        tox -v
       env:
         DJANGO: ${{ matrix.django-version }}
 


### PR DESCRIPTION
This whole time Python 3.6 (using tox 3) was running tests on `run` directory, which didn't exist.