### PR TITLE
Semi-drop Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
         # https://docs.djangoproject.com/faq/install/#what-python-version-can-i-use-with-django
         include:
           - django-version: '3.2'
-            python-version: '3.6'
-          - django-version: '3.2'
-            python-version: '3.7'
-          - django-version: '3.2'
             python-version: '3.8'
           - django-version: '3.2'
             python-version: '3.9'

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 django-simple-menu changelog
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Unreleased changes
+- Stop testing under Python 3.6, 3.7, and Django 4.0 (#138, #140)
+- Migrate from setup.cfg to pyproject.toml (#138)
+
 Version 2.1.2 - Released June 27th, 2023
  - Correctly parse a deeper menu structure (#63, #133)
  - Improved DX and CI

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,10 @@ Quickstart
 
 **Requirements:** Python 3.6+, Django 3.2+
 
+**Note:** While this package does support Python 3.6 and 3.7 as well as
+Django 4.0, we do not test the package under these versions and may miss some
+bugs.
+
 1. Install the ``django-simple-menu`` package.
 
 2. Add ``simple_menu`` to your ``INSTALLED_APPS``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers =[
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers =[
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist =
+requires =
+    tox>=4.2
+env_list =
     py3{11, 10, 9, 8}-dj42
     py3{11, 10, 9, 8}-dj41
     py3{10, 9, 8}-dj32
@@ -7,6 +9,8 @@ envlist =
 isolated_build = true
 
 [testenv]
+package = wheel
+wheel_build_env = .pkg
 deps =
     covdefaults
     coverage[toml]
@@ -17,7 +21,7 @@ deps =
 pass_env =
     FORCE_COLOR
     NO_COLOR
-setenv =
+set_env =
     DJANGO_SETTINGS_MODULE = simple_menu.test_settings
 commands =
     coverage run -m django test -v2 {posargs:simple_menu}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py3{11, 10, 9, 8}-dj42
     py3{11, 10, 9, 8}-dj41
-    py3{10, 9, 8, 7, 6}-dj32
+    py3{10, 9, 8}-dj32
     py3{12, 11, 10}-djmain
 isolated_build = true
 
@@ -24,16 +24,8 @@ commands =
     coverage report
     coverage xml
 
-[testenv:py36-dj32]
-download = true
-deps =
-    {[testenv]deps}
-    importlib_metadata
-
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
For the sake of DX, we are dropping the full support for Python 3.6 and 3.7, that is, the versions that have reached their end-of-life.

In order to fully support Django 3.2, the package can still be installed on older Python versions, and we also keep the syntax checks to ensure the app runs on older Python versions. However, we are not testing it in any way.