### PR TITLE
Feature/retain non visible children

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,5 +18,13 @@ MENU_HIDE_EMPTY
 ``MENU_HIDE_EMPTY`` controls if menu items without an explicit ``check`` callback
 should be visible even if they have no children
 
+MENU_TRIM_NON_VISIBLE_CHILD_ITEMS
+-------------------
+**Default: ``True``**
+
+``MENU_TRIM_NON_VISIBLE_CHILD_ITEMS`` controls if children of menu items should be
+removed from the ``item.children`` list if they are not visible. Retaining them
+can be useful for breadcrumbs, but can also lead to unexpected results if you do not
+check the ``visible`` property of the children in templates.
 
 .. _Django settings file: https://docs.djangoproject.com/en/dev/topics/settings/

--- a/simple_menu/menu.py
+++ b/simple_menu/menu.py
@@ -224,11 +224,12 @@ class MenuItem:
             child.parent = self
             child.process(request)
 
-        self.children = [
-            child
-            for child in children
-            if child.visible
-        ]
+        if getattr(settings, 'MENU_TRIM_NON_VISIBLE_CHILD_ITEMS', True):
+            self.children = [
+                child
+                for child in children
+                if child.visible
+            ]
         self.children.sort(key=lambda child: child.weight)
 
         # if we have no children and MENU_HIDE_EMPTY then we are not visible and should return

--- a/simple_menu/tests/test_menu.py
+++ b/simple_menu/tests/test_menu.py
@@ -4,7 +4,7 @@ from queue import Queue
 
 from django.conf import settings
 from django.template import Template, Context
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
 from simple_menu import Menu, MenuItem
@@ -264,3 +264,34 @@ class MenuItemTests(TestCase):
         self.assertTrue(item.arbitrary)
         self.assertEqual(item.dictionary, {'a': 1})
         self.assertRaises(AttributeError, lambda: item.nope)
+
+    @override_settings(MENU_TRIM_NON_VISIBLE_CHILD_ITEMS=False)
+    def test_trim_non_visible_child_items__disabled(self):
+        """
+        Ensure that non-visible child items are NOT trimmed from the menu
+        """
+        # Generate the menu
+        child_item = MenuItem("child", "/child", visible=False)
+        item = MenuItem("test", "/test", children=[child_item])
+
+        # Process the item
+        item.process()
+
+        # Check that non-visible child items are still in the menu
+        self.assertIn(child_item, item.children)
+
+    def test_trim_non_visible_child_items__enabled(self):
+        """
+        Ensure that non-visible child items are trimmed from the menu.
+
+        This is the default behaviour
+        """
+        # Generate the menu
+        child_item = MenuItem("child", "/child", visible=False)
+        item = MenuItem("test", "/test", children=[child_item])
+
+        # Process the item
+        item.process()
+
+        # Check that non-visible child items removed still in the menu
+        self.assertNotIn(child_item, item.children)

--- a/simple_menu/tests/test_menu.py
+++ b/simple_menu/tests/test_menu.py
@@ -275,7 +275,8 @@ class MenuItemTests(TestCase):
         item = MenuItem("test", "/test", children=[child_item])
 
         # Process the item
-        item.process()
+        request = RequestFactory().get('/test')
+        item.process(request)
 
         # Check that non-visible child items are still in the menu
         self.assertIn(child_item, item.children)
@@ -291,7 +292,8 @@ class MenuItemTests(TestCase):
         item = MenuItem("test", "/test", children=[child_item])
 
         # Process the item
-        item.process()
+        request = RequestFactory().get('/test')
+        item.process(request)
 
         # Check that non-visible child items removed still in the menu
         self.assertNotIn(child_item, item.children)


### PR DESCRIPTION
This PR adds the option for child menu items to not be removed from the list when `item.visible == False`.

### Usecase
I am using django-simple-menu both for menu items and for breadcrumb generation. There are several cases where a menu item is not visible to click, but can produce an entry in the breadcrumb trail.

As a work-around (and due to the simplicity of the site structure I am working on at present) I have been able to get away with simply leaving visible=True on all items and not rendering any child items. This will not work forever though.

### The change
This change adds a new setting `MENU_TRIM_NON_VISIBLE_CHILD_ITEMS` which defaults to the existing behaviour of removing all non-visible child items, but, it can be set to `False` which will then retain these items. As such, this is a non-breaking change for existing users.

The default templates in this repo should work either way because `item.visible` is always checked, but I can appreciate that some people will have custom templates which do not perform this check.

I've added some tests, but please let me know if there's anything further I can do to help get this merged in.